### PR TITLE
BID-11-BE-Implement Item Schema, Creation with Unique Slug and CRUD

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,13 +15,13 @@
      yarn add -D eslint-config-prettier eslint-plugin-prettier eslint-plugin-import
    ```
 
-3. Create essential config files for prettier, eslint and `jsconfig.json`
+3. Create essential config files for Prettier, ESLint, and `jsconfig.json`.
 
 ## Authentication and Authorization
 
-Run this command to generate `JWT Access Secrets` used in .env
+Run this command to generate `JWT Access Secrets` used in .env:
 
-```node
+```bash
 node -e "console.log(require('crypto').randomBytes(128).toString('base64'));"
 ```
 
@@ -60,12 +60,12 @@ node -e "console.log(require('crypto').randomBytes(128).toString('base64'));"
 
 ## User API Endpoints
 
-### **1. User Profile**
-
-#### Request Header (Example):
+### 1. **User Profile**
 
 **GET Request:**
 `http://localhost:8080/api/user/profile`
+
+#### Request Header (Example):
 
 ```bash
 Authorization: Bearer <token>
@@ -73,19 +73,87 @@ Authorization: Bearer <token>
 
 ## Item API Endpoints
 
-### 1. Item Create
+### 1. **Get All Items**
+
+**GET Request:**
+`http://localhost:8080/api/item/all`
+
+### 2. **Get Item by Slug**
+
+**GET Request:**
+`http://localhost:8080/api/item/:slug`
+
+#### URL Parameters:
+
+- `:slug` (string): The slug of the item to retrieve.
+
+### 3. **Create Item**
+
+**POST Request:**
+`http://localhost:8080/api/item/create`
 
 #### Request Body (Example):
 
-**POST Request**
-`http://localhost:8080/api/item/create`
-
 ```json
 {
-  "title": "Vintage Wooden Table ",
+  "title": "Vintage Wooden Table",
   "description": "A beautiful handcrafted vintage wooden table, perfect for your living room or study.",
   "startingBid": 100,
   "minimumBidIncrement": 10,
   "endTime": "2024-12-31T23:59:59Z"
 }
 ```
+
+#### Request Header:
+
+```bash
+Authorization: Bearer <token>
+```
+
+### 4. **Update Item**
+
+**PATCH Request:**
+`http://localhost:8080/api/item/update/:id`
+
+#### URL Parameters:
+
+- `:id` (string): The ID of the item to update.
+
+#### Request Body (Example):
+
+```json
+{
+  "title": "Updated Vintage Wooden Table",
+  "description": "An updated description for the vintage wooden table.",
+  "startingBid": 120
+}
+```
+
+#### Request Header:
+
+```bash
+Authorization: Bearer <token>
+```
+
+#### Authorization Check:
+
+- Only the user who created the item (identified by `sellerId`) can update it.
+
+### 5. **Delete Item**
+
+**DELETE Request:**
+`http://localhost:8080/api/item/delete/:id`
+
+#### URL Parameters:
+
+- `:id` (string): The ID of the item to delete.
+
+#### Request Header:
+
+```bash
+Authorization: Bearer <token>
+```
+
+#### Authorization Check:
+
+- Only the user who created the item (identified by `sellerId`) can delete it.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-## Initial Project Setup Steps:
+## Initial Project Setup Steps
 
 1. Project init
 
@@ -25,11 +25,11 @@ Run this command to generate `JWT Access Secrets` used in .env
 node -e "console.log(require('crypto').randomBytes(128).toString('base64'));"
 ```
 
-## API Endpoints
+## Auth API Endpoints
 
 ### 1. **User Registration**
 
-**POST Request:**  
+**POST Request:**
 `http://localhost:8080/api/auth/register`
 
 #### Request Body (Example):
@@ -46,7 +46,7 @@ node -e "console.log(require('crypto').randomBytes(128).toString('base64'));"
 
 ### 2. **User Login**
 
-**POST Request:**  
+**POST Request:**
 `http://localhost:8080/api/auth/login`
 
 #### Request Body (Example):
@@ -58,7 +58,9 @@ node -e "console.log(require('crypto').randomBytes(128).toString('base64'));"
 }
 ```
 
-### 3. **User Profile**
+## User API Endpoints
+
+### **1. User Profile**
 
 #### Request Header (Example):
 
@@ -67,4 +69,23 @@ node -e "console.log(require('crypto').randomBytes(128).toString('base64'));"
 
 ```bash
 Authorization: Bearer <token>
+```
+
+## Item API Endpoints
+
+### 1. Item Create
+
+#### Request Body (Example):
+
+**POST Request**
+`http://localhost:8080/api/item/create`
+
+```json
+{
+  "title": "Vintage Wooden Table ",
+  "description": "A beautiful handcrafted vintage wooden table, perfect for your living room or study.",
+  "startingBid": 100,
+  "minimumBidIncrement": 10,
+  "endTime": "2024-12-31T23:59:59Z"
+}
 ```

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.9.0",
     "passport": "^0.7.0",
-    "passport-jwt": "^4.0.1"
+    "passport-jwt": "^4.0.1",
+    "slugify": "^1.6.6"
   },
   "devDependencies": {
     "eslint": "^9.17.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ import express from 'express';
 
 import passport from './middleware/auth.js';
 import globalErrorHandler from './middleware/globalErrorHandler.js';
+import { ItemRoutes } from './routes/item.route.js';
 import { UserRoutes } from './routes/user.route.js';
 
 const app = express();
@@ -21,6 +22,7 @@ app.use(passport.initialize());
 
 app.use('/api/auth', UserRoutes);
 app.use('/api/user', UserRoutes);
+app.use('/api/item', ItemRoutes);
 
 app.use(globalErrorHandler);
 

--- a/backend/src/controllers/BaseController.js
+++ b/backend/src/controllers/BaseController.js
@@ -61,8 +61,10 @@ class BaseController {
     if (!data || Object.keys(data).length === 0) {
       throw new ApiError(HTTP_STATUS.BAD_REQUEST, 'Request body is missing');
     }
-
-    const result = await this.repository.update(id, data);
+    const result = await this.repository.updateById(id, data, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!result) {
       throw new ApiError(

--- a/backend/src/controllers/ItemController.js
+++ b/backend/src/controllers/ItemController.js
@@ -24,6 +24,18 @@ class ItemController extends BaseController {
         )
       );
   });
+
+  update = asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    const updates = req.body;
+    const userId = req.user.id;
+
+    const updatedItem = await this.repository.updateItem(id, userId, updates);
+
+    res
+      .status(HTTP_STATUS.OK)
+      .json(new ApiResponse(HTTP_STATUS.OK, updatedItem, 'Item updated!'));
+  });
 }
 
 export default new ItemController();

--- a/backend/src/controllers/ItemController.js
+++ b/backend/src/controllers/ItemController.js
@@ -25,6 +25,13 @@ class ItemController extends BaseController {
   create = asyncHandler(async (req, res) => {
     const newItemData = { ...req.body, sellerId: req.user._id };
 
+    if (newItemData.endTime && new Date(newItemData.endTime) <= new Date()) {
+      throw new ApiError(
+        HTTP_STATUS.BAD_REQUEST,
+        'End time must be a future date'
+      );
+    }
+
     const createdItem = await this.repository.create(newItemData);
 
     res
@@ -42,6 +49,13 @@ class ItemController extends BaseController {
     const { id } = req.params;
     const updates = req.body;
     const userId = req.user.id;
+
+    if (updates.endTime && new Date(updates.endTime) <= new Date()) {
+      throw new ApiError(
+        HTTP_STATUS.BAD_REQUEST,
+        'End time must be a future date'
+      );
+    }
 
     const updatedItem = await this.repository.updateItem(id, userId, updates);
 

--- a/backend/src/controllers/ItemController.js
+++ b/backend/src/controllers/ItemController.js
@@ -1,0 +1,29 @@
+import BaseController from './BaseController.js';
+import ItemRepository from '../repositories/ItemRepository.js';
+import ApiResponse from '../utils/ApiResponse.js';
+import asyncHandler from '../utils/asyncHandler.js';
+import HTTP_STATUS from '../utils/httpStatus.js';
+
+class ItemController extends BaseController {
+  constructor() {
+    super(new ItemRepository());
+  }
+
+  create = asyncHandler(async (req, res) => {
+    const newItemData = { ...req.body, sellerId: req.user._id };
+
+    const createdItem = await this.repository.create(newItemData);
+
+    res
+      .status(HTTP_STATUS.CREATED)
+      .json(
+        new ApiResponse(
+          HTTP_STATUS.CREATED,
+          createdItem,
+          'Item created successfully!'
+        )
+      );
+  });
+}
+
+export default new ItemController();

--- a/backend/src/controllers/ItemController.js
+++ b/backend/src/controllers/ItemController.js
@@ -36,6 +36,17 @@ class ItemController extends BaseController {
       .status(HTTP_STATUS.OK)
       .json(new ApiResponse(HTTP_STATUS.OK, updatedItem, 'Item updated!'));
   });
+
+  delete = asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    const userId = req.user.id;
+
+    await this.repository.deleteItem(id, userId);
+
+    res
+      .status(HTTP_STATUS.OK)
+      .json(new ApiResponse(HTTP_STATUS.OK, null, 'Item deleted!'));
+  });
 }
 
 export default new ItemController();

--- a/backend/src/controllers/ItemController.js
+++ b/backend/src/controllers/ItemController.js
@@ -1,5 +1,6 @@
 import BaseController from './BaseController.js';
 import ItemRepository from '../repositories/ItemRepository.js';
+import ApiError from '../utils/ApiError.js';
 import ApiResponse from '../utils/ApiResponse.js';
 import asyncHandler from '../utils/asyncHandler.js';
 import HTTP_STATUS from '../utils/httpStatus.js';
@@ -8,6 +9,18 @@ class ItemController extends BaseController {
   constructor() {
     super(new ItemRepository());
   }
+
+  getBySlug = asyncHandler(async (req, res) => {
+    const { slug } = req.params;
+    const item = await this.repository.findOne({ slug });
+
+    if (!item) {
+      throw new ApiError(HTTP_STATUS.NOT_FOUND, 'Item not found!');
+    }
+    res
+      .status(HTTP_STATUS.OK)
+      .json(new ApiResponse(HTTP_STATUS.OK, item, 'Item found!'));
+  });
 
   create = asyncHandler(async (req, res) => {
     const newItemData = { ...req.body, sellerId: req.user._id };

--- a/backend/src/models/item.model.js
+++ b/backend/src/models/item.model.js
@@ -1,0 +1,98 @@
+import mongoose from 'mongoose';
+import slugify from 'slugify';
+
+const itemSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: [true, 'Item title is required'],
+      trim: true,
+      minlength: [3, 'Title must be at least 3 characters long'],
+      maxlength: [100, 'Title cannot exceed 100 characters'],
+    },
+    description: {
+      type: String,
+      required: [true, 'Item description is required'],
+      trim: true,
+      minlength: [10, 'Description must be at least 10 characters long'],
+      maxlength: [1000, 'Description cannot exceed 1000 characters'],
+    },
+    slug: {
+      type: String,
+      // required: [true, 'Item slug is required'],
+    },
+    sellerId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: [true, 'Seller ID is required'],
+    },
+    startingBid: {
+      type: Number,
+      required: [true, 'Starting bid is required'],
+      min: [0, 'Starting bid must be a positive number'],
+    },
+    categoryId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Category',
+    },
+    status: {
+      type: String,
+      enum: {
+        values: ['active', 'sold', 'canceled'],
+        message: '{VALUE} is not a valid status',
+      },
+      default: 'active',
+    },
+    endTime: {
+      type: Date,
+      required: [true, 'Auction end time is required'],
+      validate: {
+        validator: function (value) {
+          return value > new Date();
+        },
+        message: 'End time must be a future date',
+      },
+    },
+    minimumBidIncrement: {
+      type: Number,
+      required: [true, 'Minimum bid increment is required'],
+      min: [10.0, 'Minimum bid increment must be at least 10'],
+    },
+    winnerBidId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Bid',
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  }
+);
+
+itemSchema.pre('save', async function (next) {
+  if (!this.isModified('title')) return next();
+
+  try {
+    const baseSlug = slugify(this.title, { lower: true, strict: true });
+    let uniqueSlug = baseSlug;
+    let counter = 1;
+
+    while (await this.constructor.findOne({ slug: uniqueSlug })) {
+      uniqueSlug = `${baseSlug}-${counter}`;
+      counter++;
+    }
+
+    this.slug = uniqueSlug;
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
+itemSchema.virtual('isOngoing').get(function () {
+  return this.status === 'active' && this.endTime > new Date();
+});
+
+export const Item = mongoose.model('Item', itemSchema);

--- a/backend/src/repositories/BaseRepository.js
+++ b/backend/src/repositories/BaseRepository.js
@@ -11,6 +11,10 @@ class BaseRepository {
     return this.model.findById(id);
   }
 
+  async findOne(filter) {
+    return this.model.findOne(filter);
+  }
+
   async create(data) {
     return this.model.create(data);
   }

--- a/backend/src/repositories/BaseRepository.js
+++ b/backend/src/repositories/BaseRepository.js
@@ -23,7 +23,7 @@ class BaseRepository {
   }
 
   async deleteById(id) {
-    return this.model.findByIdAndDelete(id);
+    return this.model.deleteOne({ _id: id });
   }
 }
 

--- a/backend/src/repositories/ItemRepository.js
+++ b/backend/src/repositories/ItemRepository.js
@@ -1,0 +1,10 @@
+import BaseRepository from './BaseRepository.js';
+import { Item } from '../models/item.model.js';
+
+class ItemRepository extends BaseRepository {
+  constructor() {
+    super(Item);
+  }
+}
+
+export default ItemRepository;

--- a/backend/src/repositories/ItemRepository.js
+++ b/backend/src/repositories/ItemRepository.js
@@ -33,6 +33,12 @@ class ItemRepository extends BaseRepository {
 
     return updatedItem;
   }
+
+  async deleteItem(id, userId) {
+    await this.checkIfTheOperationIsAllowed(id, userId);
+
+    return this.deleteById(id);
+  }
 }
 
 export default ItemRepository;

--- a/backend/src/repositories/ItemRepository.js
+++ b/backend/src/repositories/ItemRepository.js
@@ -1,9 +1,37 @@
 import BaseRepository from './BaseRepository.js';
 import { Item } from '../models/item.model.js';
+import ApiError from '../utils/ApiError.js';
+import HTTP_STATUS from '../utils/httpStatus.js';
 
 class ItemRepository extends BaseRepository {
   constructor() {
     super(Item);
+  }
+
+  async checkIfTheOperationIsAllowed(itemId, userId) {
+    const item = await this.findById(itemId);
+
+    if (!item) {
+      throw new ApiError(HTTP_STATUS.NOT_FOUND, 'Item not found!');
+    }
+
+    if (item.sellerId.toString() !== userId) {
+      throw new ApiError(
+        HTTP_STATUS.FORBIDDEN,
+        'You do not have permission to perform this operation'
+      );
+    }
+
+    return item;
+  }
+
+  async updateItem(id, userId, updates) {
+    const item = await this.checkIfTheOperationIsAllowed(id, userId);
+    Object.assign(item, updates);
+
+    const updatedItem = await item.save();
+
+    return updatedItem;
   }
 }
 

--- a/backend/src/routes/item.route.js
+++ b/backend/src/routes/item.route.js
@@ -7,5 +7,6 @@ const router = express.Router();
 
 router.get('/all', ItemController.getAll);
 router.post('/create', isAuthenticated, ItemController.create);
+router.patch('/update/:id', isAuthenticated, ItemController.update);
 
 export const ItemRoutes = router;

--- a/backend/src/routes/item.route.js
+++ b/backend/src/routes/item.route.js
@@ -8,5 +8,6 @@ const router = express.Router();
 router.get('/all', ItemController.getAll);
 router.post('/create', isAuthenticated, ItemController.create);
 router.patch('/update/:id', isAuthenticated, ItemController.update);
+router.delete('/delete/:id', isAuthenticated, ItemController.delete);
 
 export const ItemRoutes = router;

--- a/backend/src/routes/item.route.js
+++ b/backend/src/routes/item.route.js
@@ -5,6 +5,7 @@ import { isAuthenticated } from '../middleware/auth.js';
 
 const router = express.Router();
 
+router.get('/all', ItemController.getAll);
 router.post('/create', isAuthenticated, ItemController.create);
 
 export const ItemRoutes = router;

--- a/backend/src/routes/item.route.js
+++ b/backend/src/routes/item.route.js
@@ -1,0 +1,10 @@
+import express from 'express';
+
+import ItemController from '../controllers/ItemController.js';
+import { isAuthenticated } from '../middleware/auth.js';
+
+const router = express.Router();
+
+router.post('/create', isAuthenticated, ItemController.create);
+
+export const ItemRoutes = router;

--- a/backend/src/routes/item.route.js
+++ b/backend/src/routes/item.route.js
@@ -6,6 +6,7 @@ import { isAuthenticated } from '../middleware/auth.js';
 const router = express.Router();
 
 router.get('/all', ItemController.getAll);
+router.get('/:slug', ItemController.getBySlug);
 router.post('/create', isAuthenticated, ItemController.create);
 router.patch('/update/:id', isAuthenticated, ItemController.update);
 router.delete('/delete/:id', isAuthenticated, ItemController.delete);

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2116,6 +2116,11 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+slugify@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
+  integrity sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==
+
 sparse-bitfield@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"


### PR DESCRIPTION
## Story: [BID-11](https://welltravel.atlassian.net/browse/BID-11)

#### NOTE: Need to land before #10 

### Summary  
Implemented CRUD functionality for the marketplace items, including schema creation, secure API endpoints, and unique slug generation.  

### Features 
- **Schema:**  
  - Defined the `Item` schema with fields such as `title`, `description`, `startingBid`, `sellerId`, `categoryId`, and others.  
  - Included validations and relationships with `User` (seller) and `Category`.  

- **API Endpoints:**  
  - `GET /api/item/all` - Fetch all items.  
  - `GET /api/item/:slug` - Retrieve item details by slug.  
  - `POST /api/item/create` - Create items with seller information from the JWT token and auto-generate unique slugs.  
  - `PATCH /api/item/update/:id` - Update items if the authenticated user is the seller.  
  - `DELETE /api/item/delete/:id` - Delete items if the authenticated user is the seller.  

- **Slug Generation:**  
  - Used a Mongoose pre-save hook to create a unique slug for each item, appending counters for conflicts.  

- **Access Control:**  
  - Restricted updates and deletions to the item's seller.  